### PR TITLE
Fix command line option invoking nosetests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.1
 files = setup.py src/nose_html_reporting/__init__.py
 commit = True
 tag = False

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,3 +6,10 @@ Changelog
 -----------------------------------------
 
 * First release on PyPI.
+
+0.2.1 (2015-03-23)
+-----------------------------------------
+
+* Now plugin catches not only test logging messages, but messages called before test run. Store to separate variable
+* New report template is default one
+* Added test run time to context of the report

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,23 +60,7 @@ To set up `nose-html-reporting` for local development:
 
 6. Submit a pull request through the GitHub website.
 
-Pull Request Guidelines
------------------------
 
-If you need some code review or feedback while you're developing the code just make the pull request.
-
-For merging, you should:
-
-1. Include passing tests (run ``tox``) [1]_.
-2. Update documentation when there's new API, functionality etc. 
-3. Add a note to ``CHANGELOG.rst`` about the changes.
-4. Add yourself to ``AUTHORS.rst``.
-
-.. [1] If you don't have all the necessary python versions available locally you can rely on Travis - it will 
-       `run the tests <https://travis-ci.org/lysenkoivan/nose-html-reporting/pull_requests>`_ for each change you add in the pull request.
-       
-       It will be slower though ...
-       
 Tips
 ----
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Usage
 
   --with-html           Enable plugin HtmlOutput:  Output test results as
                         pretty html.  [NOSE_WITH_HTML]
-  --html-file=FILE      Path to html file to store the report in. Default is
+  --html-report=FILE    Path to html file to store the report in. Default is
                         nosetests.html in the working directory
   --html-report-template=FILE      Path to jinja2 file to get the report template from. Default is
                         templates/report.html from the package working directory

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(*names, **kwargs):
 
 setup(
     name="nose-html-reporting",
-    version="0.1.2",
+    version="0.2.1",
     license="BSD",
     description="Nose plugin that generates a nice html test report with ability of using template "
                 "based on jinja2 templates from any folder.",

--- a/src/nose_html_reporting/templates/report2.jinja2
+++ b/src/nose_html_reporting/templates/report2.jinja2
@@ -43,12 +43,12 @@
             left: 0px;
             top: 0px;
             /*border: solid #627173 1px; */
-            padding: 10px;
+            padding: 8px;
             background-color: #E6E6D6;
             font-family: "Lucida Console", "Courier New", Courier, monospace;
             text-align: left;
             font-size: 8pt;
-            width: 600px;
+            width: 570px;
         }
 
         }
@@ -143,6 +143,20 @@ function showTestDetail(div_id){
     }
 }
 
+function togleClass(element, clas){
+        var currentClassValue = element.className || "";
+
+        if (currentClassValue.indexOf(clas) == -1) {
+            currentClassValue += " "+clas;
+        } else {
+            currentClassValue = currentClassValue.replace(clas, "").replace("  ", " ");
+        }
+        element.className = currentClassValue.trim()
+    }
+
+function showRawLog(element){
+        togleClass(element, "popup_window")
+    }
 
 function html_escape(s) {
     s = s.replace(/&/g,'&amp;');
@@ -257,7 +271,8 @@ function html_escape(s) {
                     </div>
                 {% endif %}
             </td>
-            <td colspan='5' align='center'>
+            <td>{{ test.time }}</td>
+            <td colspan='4' align='center'>
             <!--css div popup start-->
             <a class="popup_link" onfocus='this.blur();' href="javascript:showTestDetail('div_{{ class + test.name }}')" >
                 {{ test_status }}
@@ -299,5 +314,10 @@ function html_escape(s) {
             <td>&nbsp;</td>
         </tr>
     </table>
+    <br/>
+    <a href="javascript:void(0)" onclick="showRawLog(document.getElementById('rawoutput'))">Full log raw output</a>
+    <div id='rawoutput' class='popup_window'>
+        <pre>{{ rawoutput }}</pre>
+    </div>
 </body>
 </html>

--- a/tests/test_nose_htmloutput.py
+++ b/tests/test_nose_htmloutput.py
@@ -8,7 +8,7 @@ TIMEOUT = 10
 
 def test_sample():
     with TestProcess(
-        'coverage', 'run', 'tests/nosetests.py', '--verbose', '--with-html', '--html-file=sample.html',
+        'coverage', 'run', 'tests/nosetests.py', '--verbose', '--with-html', '--html-report=sample.html',
         'tests/test_sample.py'
     ) as proc:
         with dump_on_error(proc.read):

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,5 +1,6 @@
 import unittest
 from nose.exc import SkipTest
+import time
 
 
 class TestMainCase(unittest.TestCase):
@@ -16,6 +17,10 @@ class TestMainCase(unittest.TestCase):
 
 
 class TestSecondCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print "printing: TestSecondCase.setUpClass entrypoint"
+
     def test_2a(self):
         print "printing: Verify assertTrue(1)"
         self.assertTrue(1)
@@ -47,8 +52,12 @@ def test_1():
 
 
 class TestFailedSetupCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print "printing: TestFailedSetupCase.setUpClass entrypoint"
+
     def setUp(self):
-        print("printing: Hello, world!")
+        print("printing: setUp entrypoint")
         raise Exception("raising: bad")
 
     def test_whatever(self):
@@ -56,4 +65,5 @@ class TestFailedSetupCase(unittest.TestCase):
         Verifying test short description and test error on setup fail
         """
         print "printing: Verify pass"
+        time.sleep(13)
         pass


### PR DESCRIPTION
#### Description

When nosetests is invoked by running `tox`, the `--html-file` option is included, while this has been substituted by `--html-report`. Therefore, tests fail.
#### Documentation

README.rst was outdated regarding the renaming of such option.
#### Testing

Despite this fix, unittests run by `tox` still fail (if report file has no path, `os.makedirs()` raises an error.
#### Issue

No issues are enabled (apart from pull requests), so it hasn't been possible to register this bug.
