### PR TITLE
Fix makedir error when report file has no path

### DIFF
--- a/src/nose_html_reporting/__init__.py
+++ b/src/nose_html_reporting/__init__.py
@@ -204,7 +204,7 @@ class HtmlReport(Plugin):
             )
             self.stats = {'errors': 0, 'failures': 0, 'passes': 0, 'skipped': 0}
             self.report_data = defaultdict(Group)
-            htmlfile_dirname = os.path.dirname(options.html_file)
+            htmlfile_dirname = os.path.dirname(options.html_file) or '.'
             if not os.path.exists(htmlfile_dirname):
                 os.makedirs(htmlfile_dirname)
             self.report_file = codecs.open(options.html_file, 'w', self.encoding, 'replace')


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

As mentioned in #4, `os.makedirs()` raises an error trying to create `''` directory when report file given by `--html-report` option has no path.
#### Testing

Tests passed (`tox -- py.test -k tests.test_nose_htmloutput`)
